### PR TITLE
robots.txtからTRPL 1関連のDisallowなどを削除する

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,13 +1,3 @@
 User-agent: *
 
-Disallow: /the-rust-programming-language-ja/1.6/
-Allow: /the-rust-programming-language-ja/1.6/book/
-Allow: /the-rust-programming-language-ja/1.6/rust.css
-Allow: /the-rust-programming-language-ja/1.6/*.woff
-
-Disallow: /the-rust-programming-language-ja/1.9/
-Allow: /the-rust-programming-language-ja/1.9/book/
-Allow: /the-rust-programming-language-ja/1.9/rust.css
-Allow: /the-rust-programming-language-ja/1.9/*.woff
-
 Sitemap: https://doc.rust-jp.rs/sitemap.xml


### PR DESCRIPTION
robots.txtからTRPL 1関連の`Disallow`などのエントリーを削除する。

- TRPL 1関連のページをGoogleなどのサーチエンジンのインデックスから外すために robots.txt の記述でクローリングの対象外にしていたが、すでにサーチエンジンに登録済みのページには効果がないことがわかった。
- 正しい方法は meta `noindex`タグを使うこと。[rustbookリポジトリの変更](https://github.com/rust-lang-ja/rustbook/pull/5) でタグを追加し、 the-rust-programming-language-jaリポジトリの [この変更](https://github.com/rust-lang-ja/the-rust-programming-language-ja/pull/297) でHTMLに反映する。
-  robots.txtの`Disallow`の記述は不要なうえ、それがあると、サーチエンジンのクローリングが行われず、`noindex`タグが認知されなくなってしまう。